### PR TITLE
add sign in

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,13 +43,15 @@ dependencies {
     implementation 'com.google.android.material:material:1.6.0'
     implementation 'com.google.android.gms:play-services-maps:18.0.2'
     implementation 'com.google.android.gms:play-services-location:19.0.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'com.google.android.gms:play-services-auth:20.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.4.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation platform('com.google.firebase:firebase-bom:30.0.1')
+    implementation platform('com.google.firebase:firebase-bom:30.0.2')
     implementation 'com.google.firebase:firebase-firestore-ktx'
+    implementation 'com.google.firebase:firebase-auth-ktx'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="edu.ucsb.cs.cs184.j_miller.h2go">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/AddSourceFragment.kt
+++ b/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/AddSourceFragment.kt
@@ -39,10 +39,10 @@ class AddSourceFragment : Fragment() {
         titleField = view.findViewById<EditText>(R.id.title_field)
         latitude = view.findViewById<TextView>(R.id.latitude_value)
         longitude = view.findViewById<TextView>(R.id.longitude_value)
-        confirmButton = view.findViewById<Button>(R.id.confirm_button)
+        confirmButton = view.findViewById<Button>(R.id.signin_button)
         closeButton = view.findViewById<ImageButton>(R.id.close_button)
-        typeField = view.findViewById<EditText>(R.id.type_value)
-        floorField = view.findViewById<EditText>(R.id.floor_value)
+        typeField = view.findViewById<EditText>(R.id.email_value)
+        floorField = view.findViewById<EditText>(R.id.pword_value)
 
         if (this.arguments != null) {
             viewModel.latitude = this.requireArguments().getDouble("latitude")
@@ -52,7 +52,7 @@ class AddSourceFragment : Fragment() {
         // restore state after rotation
         latitude.text = viewModel.latitude.toString()
         longitude.text = viewModel.longitude.toString()
-        titleField.setText(viewModel.titleText)
+        //save is enabled by default on editText
 
         // when confirm button clicked, if required fields are filled in,
         // write to Firebase otherwise use a toast to promp user to fill in required fields

--- a/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/LoginFragment.kt
+++ b/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/LoginFragment.kt
@@ -1,0 +1,96 @@
+package edu.ucsb.cs.cs184.j_miller.h2go
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.*
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import com.google.common.collect.Maps
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+
+class LoginFragment : Fragment() {
+
+    companion object {
+        fun newInstance() = LoginFragment()
+    }
+
+    private lateinit var viewModel: LoginViewModel
+    private lateinit var errorText: TextView
+    private lateinit var emailField: EditText
+    private lateinit var pwordField: EditText
+    private lateinit var signinButton: Button
+    private lateinit var accountButton: Button
+    private lateinit var closeButton: ImageButton
+    private lateinit var auth: FirebaseAuth
+    private lateinit var act: MapsActivity
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.login_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProvider(this).get(LoginViewModel::class.java)
+        errorText = view.findViewById<TextView>(R.id.error_text)
+        emailField = view.findViewById<EditText>(R.id.email_value)
+        pwordField = view.findViewById<EditText>(R.id.pword_value)
+        signinButton = view.findViewById<Button>(R.id.signin_button)
+        accountButton = view.findViewById<Button>(R.id.account_button)
+        closeButton = view.findViewById<ImageButton>(R.id.close_button)
+
+        act = activity as MapsActivity
+        auth = act.auth
+
+        // restore state after rotation
+        errorText.text = viewModel.errorText
+
+        accountButton.setOnClickListener {
+            auth.createUserWithEmailAndPassword(emailField.text.toString(), pwordField.text.toString())
+                .addOnCompleteListener(act) { task ->
+                    if (task.isSuccessful) {
+                        // Sign in success, update UI with the signed-in user's information
+                        //Log.i("MapsActivity", "createUserWithEmail:success")
+                        errorText.text = "Success"
+                        act.updateUI()
+                    } else {
+                        // If sign in fails, display a message to the user.
+                        //Log.i("MapsActivity", "createUserWithEmail:failure", task.exception)
+                        errorText.text = getString(R.string.auth_error_message)
+                        act.updateUI()
+                    }
+                }
+        }
+
+        signinButton.setOnClickListener {
+            auth.signInWithEmailAndPassword(emailField.text.toString(), pwordField.text.toString())
+                .addOnCompleteListener(act) { task ->
+                    if (task.isSuccessful) {
+                        // Sign in success, update UI with the signed-in user's information
+                        //Log.i("MapsActivity", "signInWithEmail:success")
+                        errorText.text = "Success (Pertaining to Sign In)"
+                        act.updateUI()
+                    } else {
+                        // If sign in fails, display a message to the user.
+                        //Log.i("MapsActivity", "signInWithEmail:failure")
+                        errorText.text = getString(R.string.auth_error_message) + " (Pertaining to Sign In)"
+                        act.updateUI()
+                    }
+                }
+        }
+
+        // when close button clicked, close the fragment
+        closeButton.setOnClickListener {
+            requireActivity().supportFragmentManager.popBackStack()
+        }
+
+    }
+
+}

--- a/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/LoginViewModel.kt
+++ b/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/LoginViewModel.kt
@@ -1,0 +1,7 @@
+package edu.ucsb.cs.cs184.j_miller.h2go
+
+import androidx.lifecycle.ViewModel
+
+class LoginViewModel : ViewModel() {
+    var errorText = ""
+}

--- a/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/MapsActivity.kt
+++ b/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/MapsActivity.kt
@@ -3,14 +3,17 @@ package edu.ucsb.cs.cs184.j_miller.h2go
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.pm.PackageManager
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.os.Looper
 import android.util.Log
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.google.android.gms.location.FusedLocationProviderClient
@@ -26,27 +29,77 @@ import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.*
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import edu.ucsb.cs.cs184.j_miller.h2go.databinding.ActivityMapsBinding
 
 class MapsActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnMapLoadedCallback {
 
+    lateinit var auth: FirebaseAuth
     private lateinit var mMap: GoogleMap
     private lateinit var mLocProvider: FusedLocationProviderClient
+    private lateinit var requestPermissionLauncher : ActivityResultLauncher<String>
     private var mLocation: LatLng? = null
     private var mLocMarker: Marker? = null
+    private var toolbarTitle: String = ""
 
-    private var locationPermissionGranted = false
     private val LOCATION_REQUEST_CODE = 101
     private lateinit var binding: ActivityMapsBinding
+    private lateinit var fab: FloatingActionButton
+    private val ucsbBounds : LatLngBounds  = LatLngBounds(
+        LatLng(34.403852, -119.854348),
+        LatLng(34.419395, -119.839153)
+    )
+    private val mapZoom : Float = 15.0f
     private val db = Firebase.firestore
+
+
+    private var locationPermissionGranted = false
+        set(value) {
+            field = value
+            updateUI()
+        }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        val inflater: MenuInflater = menuInflater
+        inflater.inflate(R.menu.toolbar_menu, menu)
+        findViewById<Toolbar>(R.id.my_toolbar).title = toolbarTitle
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
+        R.id.action_login -> {
+
+            val loginFragment = LoginFragment()
+            this.supportFragmentManager.beginTransaction()
+                .add(R.id.frameLayout, loginFragment, "addLoginFragment")
+                .addToBackStack(null).commit()
+
+            true
+        }
+
+        R.id.action_logout -> {
+            auth.signOut()
+            updateUI()
+            true
+        }
+        else -> {
+            super.onOptionsItemSelected(item)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        auth = Firebase.auth
 
         binding = ActivityMapsBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        setSupportActionBar(findViewById(R.id.my_toolbar))
+
+        fab = findViewById(R.id.fab)
+        fab.hide()
 
         // Ask user for permission to use location data
         setupPermissions()
@@ -60,7 +113,6 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnMapLoa
             .findFragmentById(R.id.map) as SupportMapFragment
         mapFragment.getMapAsync(this)
 
-        val fab: FloatingActionButton = findViewById(R.id.fab)
         if (locationPermissionGranted) {
             startLocationUpdates()
 
@@ -93,14 +145,40 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnMapLoa
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        updateUI()
+    }
+
+    fun updateUI() {
+        if (locationPermissionGranted) fab.show() else fab.hide()
+
+        // Check if user is signed in (non-null) and update UI accordingly.
+        //auth = Firebase.auth
+        val currentUser = auth.currentUser
+        if(currentUser != null){
+            toolbarTitle = getString(R.string.app_name) + " -  " + currentUser.email
+        }
+        else {
+            toolbarTitle = getString(R.string.app_name) + " - not signed in "
+        }
+
+        findViewById<Toolbar>(R.id.my_toolbar).title = toolbarTitle
+    }
+
     /* Check if the app already has permission to access location
      * if it doesn't, prompt the user to give permission
      * After this function, locationPermissionGranted should be correctly set based on user decision
      */
     private fun setupPermissions() {
+        requestPermissionLauncher =
+            registerForActivityResult(
+                ActivityResultContracts.RequestPermission()
+            ) { isGranted: Boolean ->
+                locationPermissionGranted = isGranted
+            }
         val locationPermission = ContextCompat.checkSelfPermission(
             this, Manifest.permission.ACCESS_FINE_LOCATION)
-
         if (locationPermission != PackageManager.PERMISSION_GRANTED) {
             Log.i("MapsActivity", "Permission denied")
             if (ActivityCompat.shouldShowRequestPermissionRationale(this,
@@ -154,16 +232,16 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnMapLoa
                     mLocation = LatLng(task.result.latitude, task.result.longitude)
 
                     // if location marker has not been initialized, initialize it now
-                    if (mLocMarker == null) {
-                        mLocMarker = mMap.addMarker(
+                    if (mLocMarker == null && ::mMap.isInitialized) {
+                        mLocMarker = mMap.addMarker( //lateinit property mMap has not been initialized
                             MarkerOptions()
                                 .position(mLocation!!)
                                 .title("You are Here")
                                 .icon(BitmapDescriptorFactory
-                                        .fromResource(R.drawable.location_icon_small))
+                                    .fromResource(R.drawable.location_icon_small))
                         )
                     } else { // otherwise just change its position to the new location
-                            mLocMarker!!.position = mLocation!!
+                        mLocMarker!!.position = mLocation!!
                     }
                 }
             }
@@ -240,23 +318,18 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnMapLoa
         mMap = googleMap
         mMap.setOnMapLoadedCallback(this)
 
+        val startBounds = ucsbBounds
+        mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(startBounds.center, mapZoom))
+
+        val maxBounds = ucsbBounds
+        mMap.setLatLngBoundsForCameraTarget(maxBounds)
+
         if (locationPermissionGranted) {
             getLocation()
         }
     }
 
     override fun onMapLoaded() {
-        val startBounds = LatLngBounds(
-            LatLng(34.403852, -119.854348),
-            LatLng(34.419395, -119.839153)
-        )
-        mMap.moveCamera(CameraUpdateFactory.newLatLngBounds(startBounds,1))
-
-        val maxBounds = LatLngBounds(
-            LatLng(34.406254, -119.884921),
-            LatLng(34.419395, -119.839153)
-        )
-        mMap.setLatLngBoundsForCameraTarget(maxBounds)
         showFillingLocations()
     }
 }

--- a/app/src/main/res/drawable/ic_toolbar_login.xml
+++ b/app/src/main/res/drawable/ic_toolbar_login.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10s10,-4.48 10,-10S17.52,2 12,2zM12,6c1.93,0 3.5,1.57 3.5,3.5S13.93,13 12,13s-3.5,-1.57 -3.5,-3.5S10.07,6 12,6zM12,20c-2.03,0 -4.43,-0.82 -6.14,-2.88C7.55,15.8 9.68,15 12,15s4.45,0.8 6.14,2.12C16.43,19.18 14.03,20 12,20z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_toolbar_logout.xml
+++ b/app/src/main/res/drawable/ic_toolbar_logout.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal"
+    android:autoMirrored="true">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17,7l-1.41,1.41L18.17,11H8v2h10.17l-2.58,2.58L17,17l5,-5zM4,5h8V3H4c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h8v-2H4V5z"/>
+</vector>

--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -8,6 +8,7 @@
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/map"
         android:name="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_marginTop="?attr/actionBarSize"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".MapsActivity" />
@@ -19,6 +20,17 @@
         android:layout_gravity="bottom|right"
         android:layout_margin="16dp"
         android:contentDescription="@string/fab_description"
-        android:src="@drawable/plus_icon_24dp" />
+        android:src="@drawable/plus_icon_24dp"
+        android:visibility="visible" />
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/my_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:background="?android:attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        android:visibility="visible" />
 
 </android.widget.FrameLayout>
+

--- a/app/src/main/res/layout/add_source_fragment.xml
+++ b/app/src/main/res/layout/add_source_fragment.xml
@@ -24,13 +24,13 @@
             android:text="@string/add_source_title"
             android:textSize="20sp"
             android:textStyle="bold"
-            app:layout_constraintBottom_toTopOf="@+id/instruction_text"
+            app:layout_constraintBottom_toTopOf="@+id/error_text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
-            android:id="@+id/instruction_text"
+            android:id="@+id/error_text"
             android:layout_width="300dp"
             android:layout_height="wrap_content"
             android:gravity="center"
@@ -47,7 +47,7 @@
         android:id="@+id/fields"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@+id/confirm_button"
+        app:layout_constraintBottom_toTopOf="@+id/signin_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/title_layout">
@@ -142,18 +142,18 @@
             app:layout_constraintTop_toBottomOf="@+id/lat_lng_labels">
 
             <TextView
-                android:id="@+id/type_label"
+                android:id="@+id/email_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/add_source_type_label"
                 android:textSize="20sp"
                 android:textStyle="bold"
-                app:layout_constraintBottom_toTopOf="@+id/floor_label"
+                app:layout_constraintBottom_toTopOf="@+id/pword_label"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
-                android:id="@+id/floor_label"
+                android:id="@+id/pword_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/add_source_floor_label"
@@ -161,7 +161,7 @@
                 android:textStyle="bold"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/type_label" />
+                app:layout_constraintTop_toBottomOf="@+id/email_label" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -175,20 +175,20 @@
             app:layout_constraintTop_toBottomOf="@+id/lat_lng_values">
 
             <EditText
-                android:id="@+id/type_value"
+                android:id="@+id/email_value"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:ems="10"
                 android:hint="@string/add_source_type_hint"
                 android:inputType="text"
                 android:minHeight="48dp"
-                app:layout_constraintBottom_toTopOf="@+id/floor_value"
+                app:layout_constraintBottom_toTopOf="@+id/pword_value"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 android:autofillHints="Type of Water Source" />
 
             <EditText
-                android:id="@+id/floor_value"
+                android:id="@+id/pword_value"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:ems="10"
@@ -197,14 +197,14 @@
                 android:minHeight="48dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/type_value"
+                app:layout_constraintTop_toBottomOf="@+id/email_value"
                 android:autofillHints="Floor that Source is on" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <Button
-        android:id="@+id/confirm_button"
+        android:id="@+id/signin_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/add_source_confirm_text"

--- a/app/src/main/res/layout/login_fragment.xml
+++ b/app/src/main/res/layout/login_fragment.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/frameLayout"
+    style="@style/Theme.AddSourceFragmentBG"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".AddSourceFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/fields"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@+id/signin_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/error_text"
+            android:layout_width="300dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textAlignment="center"
+            android:textColor="#FFFF0000"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/fillable_field_labels"
+            android:layout_width="180dp"
+            android:layout_height="102dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/fillable_field_values"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <TextView
+                android:id="@+id/email_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/email_label"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toTopOf="@+id/pword_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/pword_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/password_label"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/email_label" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/fillable_field_values"
+            android:layout_width="180dp"
+            android:layout_height="102dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/fillable_field_labels"
+            app:layout_constraintTop_toBottomOf="@+id/error_text">
+
+            <EditText
+                android:id="@+id/email_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:autofillHints="Type of Water Source"
+                android:ems="10"
+                android:inputType="text"
+                android:minHeight="48dp"
+                app:layout_constraintBottom_toTopOf="@+id/pword_value"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <EditText
+                android:id="@+id/pword_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:autofillHints="Floor that Source is on"
+                android:ems="10"
+                android:inputType="text"
+                android:minHeight="48dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/email_value" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <Button
+        android:id="@+id/account_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/create_account"
+        app:layout_constraintBottom_toBottomOf="@+id/signin_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/signin_button" />
+
+    <Button
+        android:id="@+id/signin_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/sign_in"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/account_button"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/fields" />
+
+    <ImageButton
+        android:id="@+id/close_button"
+        style="@style/Theme.AddSourceFragmentX"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:backgroundTint="#00FFFFFF"
+        android:contentDescription="@string/x"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/toolbar_menu.xml
+++ b/app/src/main/res/menu/toolbar_menu.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_login"
+        android:icon="@drawable/ic_toolbar_login"
+        android:title="@string/login_button_name"
+        app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/action_logout"
+        android:icon="@drawable/ic_toolbar_logout"
+        android:title="@string/logout_button_name"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,4 +14,11 @@
     <string name="add_source_floor_label">floor:</string>
     <string name="add_source_type_hint">e.g. Hydration Station</string>
     <string name="add_source_floor_hint">e.g. 1, 2, B1, etc.</string>
+    <string name="login_button_name">Log In</string>
+    <string name="logout_button_name">Log Out</string>
+    <string name="sign_in">Sign In</string>
+    <string name="create_account">Create Account</string>
+    <string name="email_label">Email</string>
+    <string name="password_label">Password</string>
+    <string name="auth_error_message">Authentication failed.</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,6 +12,8 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
     </style>
 
     <style name="Theme.AddSourceFragmentBG" parent="Theme.Design">


### PR DESCRIPTION
Closes #3
The user sees a toolbar with an account button and a sign out button on the main screen. The account button takes the user to a page where they can use an email address and password to create an account or sign in with an already created account. Upon signing in, the toolbar will display the email associated with their account. The sign out button signs the user out. The current UI and feedback messages are basically placeholders for now.

I also fixed the FAB not showing if the user doesn't have the permission granted on startup but later accepts the system permission request dialogue. I also set the map's location before it's first shown, so there's no awkward jump from a null position. The initial zoom level of the map is also now uncoupled by the screen orientation and size.