### PR TITLE
Fix Markers Being Clickable through Fragments

### DIFF
--- a/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/MapsActivity.kt
+++ b/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/MapsActivity.kt
@@ -328,6 +328,11 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnMapLoa
         mMap = googleMap
         mMap.setOnMapLoadedCallback(this)
         mMap.setOnMarkerClickListener { marker ->
+
+            /* If there's already a fragment up, don't do anything. */
+            if (this.supportFragmentManager.backStackEntryCount!=0)
+                return@setOnMarkerClickListener true
+
             val bundle = Bundle()
             bundle.putDouble("latitude",marker.position.latitude)
             bundle.putDouble("longitude",marker.position.longitude)


### PR DESCRIPTION
Closes Issue #37 
Adds a conditional in the onMarkerClickListener that tells it to do nothing if a fragment is already open (i.e. the Info Fragment).