### PR TITLE
EM - disabled opening new toolbar fragments while already in a fragment

### DIFF
--- a/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/MapsActivity.kt
+++ b/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/MapsActivity.kt
@@ -194,7 +194,7 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnMapLoa
         }
         // if have location, set FAB to open fragment to add sources to database
         fab.setOnClickListener {
-            if(locationPermissionGranted) {
+            if(locationPermissionGranted && mLocation != null) {
                 getLocation()
                 val bundle = Bundle()
                 bundle.putDouble("latitude", mLocation!!.latitude)

--- a/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/MapsActivity.kt
+++ b/app/src/main/java/edu/ucsb/cs/cs184/j_miller/h2go/MapsActivity.kt
@@ -116,42 +116,41 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnMapLoa
             /* Basically, don't do anything if a fragment's already up.
             * Same code for the other cases; there may be a prettier way of
             * accomplishing this. */
-            if (this.supportFragmentManager.backStackEntryCount != 0)
-                true
-
-            val loginFragment = LoginFragment()
-            this.supportFragmentManager.beginTransaction()
-                .add(R.id.frameLayout, loginFragment, "addLoginFragment")
-                .addToBackStack(null).commit()
+            if (this.supportFragmentManager.backStackEntryCount == 0) {
+                val loginFragment = LoginFragment()
+                this.supportFragmentManager.beginTransaction()
+                    .add(R.id.frameLayout, loginFragment, "addLoginFragment")
+                    .addToBackStack(null).commit()
+            }
 
             true
         }
 
         R.id.action_logout -> {
 
-            if (this.supportFragmentManager.backStackEntryCount != 0)
-                true
+            if (this.supportFragmentManager.backStackEntryCount == 0) {
+                auth.signOut()
+                updateUI()
+            }
 
-            auth.signOut()
-            updateUI()
             true
         }
 
         R.id.action_filter -> {
 
-            if (this.supportFragmentManager.backStackEntryCount != 0)
-                true
+            if (this.supportFragmentManager.backStackEntryCount == 0) {
+                val bundle = Bundle()
+                if (auth.currentUser != null)
+                    bundle.putString("userID", auth.currentUser!!.uid)
+                else
+                    bundle.putString("userID", "")
+                val filterFragment = FilterFragment()
+                filterFragment.arguments = bundle
+                this.supportFragmentManager.beginTransaction()
+                    .add(R.id.frameLayout, filterFragment, "addFilterFragment")
+                    .addToBackStack(null).commit()
+            }
 
-            val bundle = Bundle()
-            if (auth.currentUser != null)
-                bundle.putString("userID",auth.currentUser!!.uid)
-            else
-                bundle.putString("userID","")
-            val filterFragment = FilterFragment()
-            filterFragment.arguments = bundle
-            this.supportFragmentManager.beginTransaction()
-                .add(R.id.frameLayout, filterFragment, "addFilterFragment")
-                .addToBackStack(null).commit()
             true
         }
 


### PR DESCRIPTION
Closes #45.

A relatively quick fix, I added a check to each of the onOptionsItemSelected cases that ensures a new fragment is not opened if one is not already up. 